### PR TITLE
Add FOREIGN statement to all LEF views

### DIFF
--- a/sky130_sram_1kbyte_1rw1r_32x256_8/sky130_sram_1kbyte_1rw1r_32x256_8.lef
+++ b/sky130_sram_1kbyte_1rw1r_32x256_8/sky130_sram_1kbyte_1rw1r_32x256_8.lef
@@ -7,6 +7,7 @@ UNITS
 END UNITS
 MACRO sky130_sram_1kbyte_1rw1r_32x256_8
    CLASS BLOCK ;
+   FOREIGN sky130_sram_1kbyte_1rw1r_32x256_8 ;
    SIZE 479.78 BY 397.5 ;
    SYMMETRY X Y R90 ;
    PIN din0[0]

--- a/sky130_sram_1kbyte_1rw1r_8x1024_8/sky130_sram_1kbyte_1rw1r_8x1024_8.lef
+++ b/sky130_sram_1kbyte_1rw1r_8x1024_8/sky130_sram_1kbyte_1rw1r_8x1024_8.lef
@@ -7,6 +7,7 @@ UNITS
 END UNITS
 MACRO sky130_sram_1kbyte_1rw1r_8x1024_8
    CLASS BLOCK ;
+   FOREIGN sky130_sram_1kbyte_1rw1r_8x1024_8 ;
    SIZE 455.3 BY 446.46 ;
    SYMMETRY X Y R90 ;
    PIN din0[0]

--- a/sky130_sram_2kbyte_1rw1r_32x512_8/sky130_sram_2kbyte_1rw1r_32x512_8.lef
+++ b/sky130_sram_2kbyte_1rw1r_32x512_8/sky130_sram_2kbyte_1rw1r_32x512_8.lef
@@ -7,6 +7,7 @@ UNITS
 END UNITS
 MACRO sky130_sram_2kbyte_1rw1r_32x512_8
    CLASS BLOCK ;
+   FOREIGN sky130_sram_2kbyte_1rw1r_32x512_8 ;
    SIZE 683.1 BY 416.54 ;
    SYMMETRY X Y R90 ;
    PIN din0[0]


### PR DESCRIPTION
Please see https://github.com/librelane/librelane/pull/719 for context.

Without the `FOREIGN` statement, KLayout will not create a ghost cell to be later replaced with the contents of the GDS.

This used to work in OpenLane only because the default behavior for cell conflict resolution was “AddToCell”.
However, "RenameCell" should be the default, as it is in magic.